### PR TITLE
chore(linux-shared-lib): fix typos; apply clang-format

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,8 @@ repos:
     rev: v1.7.7
     hooks:
       - id: actionlint
+
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v21.1.0
+    hooks:
+      - id: clang-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,8 @@ repos:
       - id: actionlint
 
   - repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v21.1.0
+    # 'clang-format' may produce different result for different versions
+    # with the same config. Better to choose one version and stick to it.
+    rev: 86fdcc9bd34d6afbbd29358b97436c8ffe3aa3b2  # frozen: v21.1.0
     hooks:
       - id: clang-format

--- a/linux-shared-lib/.clang-format
+++ b/linux-shared-lib/.clang-format
@@ -1,0 +1,12 @@
+---
+BasedOnStyle: Google
+IndentWidth: 2
+IndentPPDirectives: AfterHash
+IncludeCategories:
+  # STL has lowest priority
+  - Regex:           '<[[:alnum:].]+>'
+    Priority:        10
+  # everything else - high
+  - Regex:           '.*'
+    Priority:        1
+    SortPriority:    0

--- a/linux-shared-lib/app/src/main.cpp
+++ b/linux-shared-lib/app/src/main.cpp
@@ -1,13 +1,14 @@
 #include "foo.hpp"
+
 #include <iostream>
 
 int main() {
-    const auto n = libfoo::foo();
-    std::cout << "Number from function: " << n << std::endl;
+  const auto n = libfoo::foo();
+  std::cout << "Number from function: " << n << std::endl;
 
-    libfoo::ClassA obj;
-    const auto n_from_obj = obj.foo();
-    std::cout << "Number from class: " << n_from_obj << std::endl;
+  libfoo::ClassA obj;
+  const auto n_from_obj = obj.foo();
+  std::cout << "Number from class: " << n_from_obj << std::endl;
 
-    return 0;
+  return 0;
 }

--- a/linux-shared-lib/libfoo/CMakeLists.txt
+++ b/linux-shared-lib/libfoo/CMakeLists.txt
@@ -24,7 +24,7 @@ option(LIBFOO_STRIP "Strip debug info into as separate file" OFF)
 message(STATUS "Strip debug info into: ${LIBFOO_STRIP}")
 
 option(LIBFOO_VERSIONING "Add version to so file" OFF)
-message(STATUS "Strip debug info into: ${LIBFOO_VERSIONING}")
+message(STATUS "Versioning via SONAME: ${LIBFOO_VERSIONING}")
 
 if(LIBFOO_SHARED)
     set(BUILD_TYPE_LIBFOO SHARED)

--- a/linux-shared-lib/libfoo/include/foo.hpp
+++ b/linux-shared-lib/libfoo/include/foo.hpp
@@ -3,20 +3,20 @@
 // foo_EXPORTS is defined automatically by cmake
 // see: https://cmake.org/cmake/help/latest/prop_tgt/DEFINE_SYMBOL.html
 #if defined(foo_EXPORTS) && defined(API_VISIBILITY)
-#   define PUBLIC_API_FOO __attribute__((visibility("default")))
+#  define PUBLIC_API_FOO __attribute__((visibility("default")))
 #else
-#   define PUBLIC_API_FOO
+#  define PUBLIC_API_FOO
 #endif
 
 namespace libfoo {
 
 class PUBLIC_API_FOO ClassA {
-public:
-    int foo();
+ public:
+  int foo();
 };
 
 PUBLIC_API_FOO int foo();
 
 bool foo2();
 
-}  // libfoo
+}  // namespace libfoo

--- a/linux-shared-lib/libfoo/src/foo.cpp
+++ b/linux-shared-lib/libfoo/src/foo.cpp
@@ -1,25 +1,27 @@
 #include "foo.hpp"
+
 #include "internal.hpp"
+
 #include <iostream>
 
 namespace libfoo {
 
 int ClassA::foo() {
-    const auto msg = internal::foo_internal();
-    std::cout << "ClassA::foo: " << msg << std::endl;
-    auto result = msg.size();
-    return msg.size();
+  const auto msg = internal::foo_internal();
+  std::cout << "ClassA::foo: " << msg << std::endl;
+  auto result = msg.size();
+  return msg.size();
 }
 
 int foo() {
-    const auto msg = internal::foo_internal();
-    std::cout << "foo: " << msg << std::endl;
-    return msg.size();
+  const auto msg = internal::foo_internal();
+  std::cout << "foo: " << msg << std::endl;
+  return msg.size();
 }
 
 bool foo2() {
-    const auto msg = internal::foo_internal();
-    return msg.size() > 5;
+  const auto msg = internal::foo_internal();
+  return msg.size() > 5;
 }
 
-}  // libfoo
+}  // namespace libfoo

--- a/linux-shared-lib/libfoo/src/internal.cpp
+++ b/linux-shared-lib/libfoo/src/internal.cpp
@@ -1,7 +1,5 @@
 #include "internal.hpp"
 
 namespace libfoo::internal {
-std::string foo_internal() {
-    return "hello, world!";
-}
-}  // libfoo::internal
+std::string foo_internal() { return "hello, world!"; }
+}  // namespace libfoo::internal

--- a/linux-shared-lib/libfoo/src/internal.hpp
+++ b/linux-shared-lib/libfoo/src/internal.hpp
@@ -4,4 +4,4 @@
 
 namespace libfoo::internal {
 std::string foo_internal();
-} // libfoo::internal
+}  // namespace libfoo::internal

--- a/linux-shared-lib/libfoo/tests/test.cpp
+++ b/linux-shared-lib/libfoo/tests/test.cpp
@@ -1,12 +1,14 @@
-#include <foo.hpp>
+#include "foo.hpp"
+
 #include <iostream>
 
 int main() {
-    const auto n = libfoo::foo();
-    std::cout << n << std::endl;
+  const auto n = libfoo::foo();
+  std::cout << n << std::endl;
 
-    // fails to compile if libfoo uses PUBLIC_API macro to define symbol visibility
-    // const auto b = libfoo::foo2();
-    // std::cout << b << std::endl;
-    return 0;
+  // fails to compile if libfoo uses PUBLIC_API macro to define symbol
+  // visibility
+  // const auto b = libfoo::foo2();
+  // std::cout << b << std::endl;
+  return 0;
 }


### PR DESCRIPTION
- update misspelled cmake option;
- add clang-format to pre-commit;