### PR TITLE
fix(linux-shared-lib): use extern C++ and demangled symbols

### DIFF
--- a/linux-shared-lib/libfoo/libfoo.map
+++ b/linux-shared-lib/libfoo/libfoo.map
@@ -1,4 +1,4 @@
-LIB_FOO_1 {
+{
     global:
         extern "C++" {
             libfoo::*;

--- a/linux-shared-lib/libfoo/libfoo.map
+++ b/linux-shared-lib/libfoo/libfoo.map
@@ -1,6 +1,8 @@
-{
+LIB_FOO_1 {
     global:
-        _ZN6libfoo*;
+        extern "C++" {
+            libfoo::*;
+        };
     local:
         _ZN6libfoo8internal*;  # won't work :(
         *;


### PR DESCRIPTION
Use `extern "C++"` with demangled symbols in version script file.

Corresponding update in the blog post: https://github.com/AndreyNautilus/AndreyNautilus.github.io/pull/91